### PR TITLE
[기능추가] line graph #70 일별 지출 데이터 그래프와 연동

### DIFF
--- a/client/src/component/Bargraph.scss
+++ b/client/src/component/Bargraph.scss
@@ -71,11 +71,11 @@ figure{
     transition: width 2s ease;
     &:hover,
     &:focus {
-      fill: red !important;
+      fill: red;
     } 
     &:hover ~ .bar-category,
     &:focus ~ .bar-category {
-      color: red !important;
+      color: red;
     } 
    
 

--- a/client/src/component/LineGraph.js
+++ b/client/src/component/LineGraph.js
@@ -39,10 +39,15 @@ export default function LineGraph() {
         .join("")}
       <text x="400" y="440" class="label-title">날짜</text>
     </g>
-    <g class="labels y-labels">
+    <g class="labels y-labels grid-line">
     ${Array(10)
       .fill()
-      .map((item, i) => `<text x="80" y="${370 - i * 36.5}">${5 * i}만</text>`)
+      .map(
+        (item, i) => `<text x="80" y="${370 - i * 36.5}">${5 * i}만</text>
+        <line x1="90" x2="760" y1="${370 - i * 36.5}" y2="${
+          370 - i * 36.5
+        }"></line>`
+      )
       .join("")}
   <text x="30" y="200" class="label-title">금액</text>
     </g>

--- a/client/src/component/LineGraph.js
+++ b/client/src/component/LineGraph.js
@@ -16,11 +16,9 @@ export default function LineGraph() {
     const iter = lastDay % 5 === 0 ? lastDay / 5 : parseInt(lastDay / 5) + 1;
 
     const html = `
-    <div style="margin:-20px" class="${
-      getCategoryRadioChecked() ? "hidden" : ""
-    }">
+    <div class="${getCategoryRadioChecked() ? "hidden" : ""}">
       <figcaption style="margin:0">일별 지출</figcaption>
-      <svg version="1.2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="graph" aria-labelledby="title" role="img">
+      <svg viewBox="0 0 800 800" version="1.2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="graph" aria-labelledby="title" role="img">
     <g class="grid x-grid" id="xGrid">
       <line x1="90" x2="90" y1="5" y2="370"></line>
     </g>
@@ -37,7 +35,7 @@ export default function LineGraph() {
             }일</text>`
         )
         .join("")}
-      <text x="400" y="440" class="label-title">날짜</text>
+      <text x="440" y="440" class="label-title">날짜</text>
     </g>
     <g class="labels y-labels grid-line">
     ${Array(10)
@@ -50,27 +48,7 @@ export default function LineGraph() {
       )
       .join("")}
   <text x="30" y="200" class="label-title">금액</text>
-    </g>
-    <g class="data" data-setname="Our first data set">
-    ${Array(+lastDay)
-      .fill()
-      .map((item, i) => {
-        const date = `${year}-${month < 10 ? `0${month}` : month}-${
-          i < 9 ? `0${i + 1}` : i + 1
-        }`;
-        let records = getLedgerItemByDate(date);
-        let outcomeSum = 0;
-        if (records) {
-          outcomeSum = getDailyOutcomeSum(records);
-        }
-        const unit = outcomeSum / 10000 / 5;
-        return `<circle cx="${110 + i * (650 / lastDay)}" cy="${
-          370 - unit * 36.5
-        }" data-value="${outcomeSum}" r="4"/>`;
-      })}
-    </g>
-   
-    <polyline
+  <polyline
     fill="none"
     stroke="#0074d9"
     stroke-width="3"
@@ -86,9 +64,49 @@ export default function LineGraph() {
           outcomeSum = getDailyOutcomeSum(records);
         }
         const unit = outcomeSum / 10000 / 5;
-        return `${110 + i * (650 / lastDay)}, ${370 - unit * 36.5}`;
+        if (unit <= 9)
+          return `${110 + i * (650 / lastDay)}, ${370 - unit * 36.5}`;
+        else return `${110 + i * (650 / lastDay)}, ${370 - 9.5 * 36.5}`;
       })}
       "/>
+    </g>
+    <g class="data" data-setname="Our first data set">
+    ${Array(+lastDay)
+      .fill()
+      .map((item, i) => {
+        const date = `${year}-${month < 10 ? `0${month}` : month}-${
+          i < 9 ? `0${i + 1}` : i + 1
+        }`;
+        let records = getLedgerItemByDate(date);
+        let outcomeSum = 0;
+        if (records) {
+          outcomeSum = getDailyOutcomeSum(records);
+        }
+        const unit = outcomeSum / 10000 / 5;
+        return `${
+          unit <= 9
+            ? `<circle cx="${110 + i * (650 / lastDay)}" cy="${
+                370 - unit * 36.5
+              }" data-value="${outcomeSum}" r="4"/>`
+            : `<circle cx="${110 + i * (650 / lastDay)}" cy="${
+                370 - 9.5 * 36.5
+              }" data-value="${outcomeSum}" r="4"/>`
+        }
+        ${
+          outcomeSum === 0
+            ? ""
+            : outcomeSum > 450000
+            ? `<text class="amount-label" x="${90 + i * (650 / lastDay)}" y="${
+                350 - 9.2 * 36.5
+              }">
+      ${parseInt(outcomeSum / 10000)} 만원</text>`
+            : `<text class="amount-label" x="${90 + i * (650 / lastDay)}" y="${
+                350 - unit * 36.5
+              }">
+${parseInt(outcomeSum / 10000)} 만원</text>`
+        }`;
+      })}
+    </g>
     </svg>
     </div>
       `;

--- a/client/src/component/LineGraph.js
+++ b/client/src/component/LineGraph.js
@@ -1,19 +1,20 @@
 import "./LineGraph.scss";
 import {
-  getStatisticsData,
   getCurrentDate,
   subscribe,
   getCategoryRadioChecked,
+  getLedgerItemByDate,
 } from "../store";
+import { getDailyOutcomeSum } from "../util/sumCalculator";
 
 export default function LineGraph() {
   const componentName = "linegraph";
 
   function render() {
-    const statistics = getStatisticsData();
     const { year, month } = getCurrentDate();
     const lastDay = new Date(year, month, 0).toString().split(" ")[2];
     const iter = lastDay % 5 === 0 ? lastDay / 5 : parseInt(lastDay / 5) + 1;
+
     const html = `
     <div style="margin:-20px" class="${
       getCategoryRadioChecked() ? "hidden" : ""
@@ -46,22 +47,43 @@ export default function LineGraph() {
   <text x="30" y="200" class="label-title">금액</text>
     </g>
     <g class="data" data-setname="Our first data set">
-        <circle cx="90" cy="192" data-value="7.2" r="4"></circle>
-        <circle cx="240" cy="141" data-value="8.1" r="4"></circle>
-        <circle cx="388" cy="179" data-value="7.7" r="4"></circle>
-        <circle cx="531" cy="200" data-value="6.8" r="4"></circle>
-        <circle cx="677" cy="104" data-value="6.7" r="4"></circle>
+    ${Array(+lastDay)
+      .fill()
+      .map((item, i) => {
+        const date = `${year}-${month < 10 ? `0${month}` : month}-${
+          i < 9 ? `0${i + 1}` : i + 1
+        }`;
+        let records = getLedgerItemByDate(date);
+        let outcomeSum = 0;
+        if (records) {
+          outcomeSum = getDailyOutcomeSum(records);
+        }
+        const unit = outcomeSum / 10000 / 5;
+        return `<circle cx="${110 + i * (650 / lastDay)}" cy="${
+          370 - unit * 36.5
+        }" data-value="${outcomeSum}" r="4"/>`;
+      })}
     </g>
+   
     <polyline
     fill="none"
     stroke="#0074d9"
     stroke-width="3"
-    points="
-      90,192,
-      240,141
-      388,179
-      531,200,
-      677,104"/>
+    points="90,370,${Array(+lastDay)
+      .fill()
+      .map((item, i) => {
+        const date = `${year}-${month < 10 ? `0${month}` : month}-${
+          i < 9 ? `0${i + 1}` : i + 1
+        }`;
+        let records = getLedgerItemByDate(date);
+        let outcomeSum = 0;
+        if (records) {
+          outcomeSum = getDailyOutcomeSum(records);
+        }
+        const unit = outcomeSum / 10000 / 5;
+        return `${110 + i * (650 / lastDay)}, ${370 - unit * 36.5}`;
+      })}
+      "/>
     </svg>
     </div>
       `;

--- a/client/src/component/LineGraph.scss
+++ b/client/src/component/LineGraph.scss
@@ -25,6 +25,12 @@
   stroke-width: 1;
 }
 
+.grid-line{
+  stroke: black;
+  stroke-dasharray: 2;
+  stroke-width: 1;
+}
+
 .data {
   fill: red;
   stroke-width: 1; 

--- a/client/src/component/LineGraph.scss
+++ b/client/src/component/LineGraph.scss
@@ -29,3 +29,15 @@
   fill: red;
   stroke-width: 1; 
 }
+
+polyline{
+  stroke-dasharray: 1000;
+  stroke-dashoffset: 1000;
+  animation: dash 5s linear forwards;
+}
+
+@keyframes dash {
+  to {
+    stroke-dashoffset: 0;
+  }
+}

--- a/client/src/component/LineGraph.scss
+++ b/client/src/component/LineGraph.scss
@@ -1,9 +1,12 @@
 
 .linegraph{
     width:100%;
-    height:600px;
+    height:800px;
 }
 
+// .svg-line-graph{
+//   height:700px;
+// }
 
 .graph .labels.x-labels {
   text-anchor: middle;
@@ -15,7 +18,8 @@
 
 
 .graph {
-  height: 500px;
+  padding:20px;
+  height: 700px;
   width: 800px;
 }
 
@@ -37,7 +41,7 @@
 }
 
 polyline{
-  stroke-dasharray: 2000;
+  stroke-dasharray: 3000;
   stroke-dashoffset: 2000;
   animation: dash 2s linear forwards;
 }
@@ -46,4 +50,10 @@ polyline{
   to {
     stroke-dashoffset: 0;
   }
+}
+
+.amount-label{
+  fill:#142850;
+  z-index:1;
+  font-size:20px;
 }

--- a/client/src/component/LineGraph.scss
+++ b/client/src/component/LineGraph.scss
@@ -31,9 +31,9 @@
 }
 
 polyline{
-  stroke-dasharray: 1000;
-  stroke-dashoffset: 1000;
-  animation: dash 5s linear forwards;
+  stroke-dasharray: 2000;
+  stroke-dashoffset: 2000;
+  animation: dash 2s linear forwards;
 }
 
 @keyframes dash {

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -141,8 +141,7 @@ export async function addNewLedgeritem(date, newItem) {
   const newLedgerItem = { ...newItem[date], created_at: date };
   await createTransactionFromServer(newLedgerItem);
   await fetchLedgerItem();
-  
-  console.log("add item", newLedgerItem);
+
   const inputs = $all(".form-input-text");
   inputs.forEach((input) => {
     input.value = "";
@@ -205,6 +204,10 @@ export function toggleModal() {
 
 // 달력
 
+export function fetchCurrentDate(){
+  
+}
+
 export function getCurrentDate() {
   return state.currentDate.data;
 }
@@ -216,9 +219,9 @@ export async function toPrevMonth() {
   } else {
     --state.currentDate.data.month;
   }
-  
+
   publish(state.currentDate);
-  
+
   await fetchLedgerItem(state.currentDate);
   publish(state.ledgerItem);
 }

--- a/client/src/util/constant.js
+++ b/client/src/util/constant.js
@@ -2,7 +2,15 @@ export const INCOME_TYPE = "수입";
 export const OUTCOME_TYPE = "지출";
 export const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
 export const INCOME_CATEGORY = ["월급", "용돈", "기타수입"];
-export const OUTCOME_CATEGORY = ["식비", "생활", "쇼핑/뷰티", "교통", "의료/건강", "문화/여가", "미분류"];
+export const OUTCOME_CATEGORY = [
+  "식비",
+  "생활",
+  "쇼핑/뷰티",
+  "교통",
+  "의료/건강",
+  "문화/여가",
+  "미분류",
+];
 export const PIECHART_RADIUS = 30;
 export const PI = 3.141592;
 export const PIECHART_CIRCUMFERENCE = 2 * PIECHART_RADIUS * PI;


### PR DESCRIPTION
- 일별 지출 합계를 라인그래프에 보여줄 수 있도록 구현했습니다

- 데이터 fetch 관련 문제를 한꺼번에 처리하는 게 나을 것 같아 별다른 fetch함수를 불러오지 않았습니다
 > list페이지로 먼저 간 후 통계 페이지로 가면 잘 작동됩니다 이 부분은 오후에 수정하겠습니다

- 실제 데이터 연동까지 했고 추가로 애니메이션 추가와 라벨을 붙이려고 합니다 