### PR TITLE
[기능추가] Form 컴포넌트 내용지우기 기능 구현 및 transaction 삭제  api  연동

### DIFF
--- a/client/src/component/Calendar.js
+++ b/client/src/component/Calendar.js
@@ -6,7 +6,6 @@ import {
   getCurrentDate,
   subscribe,
   unsubscribe,
-  getLedgerItem,
 } from "../store";
 
 export default function Calendar() {
@@ -17,6 +16,7 @@ export default function Calendar() {
     if (nextPageURI === "calendar") return;
     
     unsubscribe(componentName, "currentDate");
+    unsubscribe(componentName, "ledgerItem");
   }
 
   window.addEventListener("popstate", onPopState.bind(this));

--- a/client/src/component/Form.js
+++ b/client/src/component/Form.js
@@ -12,6 +12,8 @@ import {
   getIsFormUpdateMode,
   updateLedgerItem,
   setIsFormUpdateMode,
+  deleteLedgerItem,
+  clearToUpdateTransaction,
 } from "../store";
 import {
   isNumber,
@@ -119,6 +121,7 @@ export default function Form() {
       tmp[curdate.value]["t_id"] = t_id;
       updateLedgerItem(curdate.value, tmp);
       setIsFormUpdateMode(false);
+      clearToUpdateTransaction();
       return;
     }
     addNewLedgeritem(curdate.value, tmp);
@@ -168,7 +171,15 @@ export default function Form() {
     if (!isFormUpdateMode) {
       clearInputForm();
       resetSelectElements();
+      return;
     }
+
+    const toDeleteTransaction = getToUpdateTransaction();
+    const { t_id } = toDeleteTransaction;
+
+    deleteLedgerItem(t_id);
+    setIsFormUpdateMode(false);
+    clearToUpdateTransaction();
   }
 
   function render() {
@@ -183,14 +194,14 @@ export default function Form() {
             <div class="form-col">
               <label for="inout">분류</label>
               <button class="form-income-btn ${
-                (!isFormUpdateMode && isFormIncomeSelected) ||
-                toUpdateTransaction.t_type === INCOME_TYPE
+                ((!isFormUpdateMode && isFormIncomeSelected) ||
+                (toUpdateTransaction && toUpdateTransaction.t_type === INCOME_TYPE))
                   ? "category-btn-income-clicked"
                   : ""
               }">수입</button>
               <button class="form-outcome-btn ${
-                (!isFormUpdateMode && isFormOutcomeSelected) ||
-                toUpdateTransaction.t_type === OUTCOME_TYPE
+                ((!isFormUpdateMode && isFormOutcomeSelected) ||
+                (toUpdateTransaction && toUpdateTransaction.t_type === OUTCOME_TYPE))
                   ? "category-btn-outcome-clicked"
                   : ""
               }">지출</button>

--- a/client/src/component/Form.js
+++ b/client/src/component/Form.js
@@ -184,6 +184,9 @@ export default function Form() {
                   ? "category-btn-outcome-clicked"
                   : ""
               }">지출</button>
+              <button class="form-delete-btn">
+                ${isFormUpdateMode? "삭제" : "내용 지우기"}
+              </button>
             </div>
           </div>
           <div class="form-row">

--- a/client/src/component/Form.js
+++ b/client/src/component/Form.js
@@ -1,5 +1,5 @@
 import "./Form.scss";
-import { bindEventAll, bindEvent, $, $id, getNextPageURI } from "../util/util";
+import { bindEventAll, bindEvent, $, $id, getNextPageURI, clearInputForm, resetSelectElements } from "../util/util";
 import {
   subscribe,
   addNewLedgeritem,
@@ -11,6 +11,7 @@ import {
   getToUpdateTransaction,
   getIsFormUpdateMode,
   updateLedgerItem,
+  setIsFormUpdateMode,
 } from "../store";
 import {
   isNumber,
@@ -117,6 +118,7 @@ export default function Form() {
     if (isFormUpdateMode) {
       tmp[curdate.value]["t_id"] = t_id;
       updateLedgerItem(curdate.value, tmp);
+      setIsFormUpdateMode(false);
       return;
     }
     addNewLedgeritem(curdate.value, tmp);
@@ -159,6 +161,14 @@ export default function Form() {
       return false;
     }
     return true;
+  }
+
+  function onFormDeleteBtnClick(e) {
+    const isFormUpdateMode = getIsFormUpdateMode();
+    if (!isFormUpdateMode) {
+      clearInputForm();
+      resetSelectElements();
+    }
   }
 
   function render() {
@@ -285,6 +295,7 @@ export default function Form() {
     bindEvent("input#transaction-content", "input", contentValidationCheck);
     bindEvent("input#transaction-content", "keyup", submitByEnter);
     bindEvent("button.form-submit-btn", "click", submitForm);
+    bindEvent("button.form-delete-btn", "click", onFormDeleteBtnClick);
   }
 
   subscribe(componentName, "ledgerItem", render);

--- a/client/src/component/Form.scss
+++ b/client/src/component/Form.scss
@@ -54,6 +54,15 @@
 
   &-col{
     margin:0;
+    width:100%;
+    position:relative;
+
+    & .form-delete-btn{
+      position: absolute;
+      top: 1rem;
+      right: 0;
+      margin: 0;
+    }
   }
 
   &-col-2 {

--- a/client/src/service/transactionService.js
+++ b/client/src/service/transactionService.js
@@ -18,6 +18,6 @@ export async function updateTransaction(t_id, editedItem) {
   return await patchFetchManger(`/transaction/${t_id}`, editedItem);
 }
 
-export async function deleteTransactionFromServer(t_id) {
+export async function deleteTransaction(t_id) {
   return await deleteFetchManager(`/transaction/${t_id}`);
 }

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -9,6 +9,7 @@ import {
   createTransaction,
   getTransactionFromServer,
   updateTransaction,
+  deleteTransaction,
 } from "./service/transactionService";
 
 export const state = {
@@ -122,6 +123,10 @@ export function getToUpdateTransaction(data) {
   return state.toUpdateTransaction.data;
 }
 
+export function clearToUpdateTransaction() {
+  state.toUpdateTransaction.data = null;
+}
+
 export function setIsFormUpdateMode(data) {
   state.isFormUpdateMode.data = data;
   publish(state.isFormUpdateMode);
@@ -168,6 +173,11 @@ export async function updateLedgerItem(date, editedItem) {
   const editedLedgerItem = {...editedItem[date], created_at: date};  
 
   await updateTransaction(editedLedgerItem.t_id, editedItem);
+  await fetchLedgerItem();
+}
+
+export async function deleteLedgerItem(t_id) {
+  await deleteTransaction(t_id);
   await fetchLedgerItem();
 }
 

--- a/client/src/util/util.js
+++ b/client/src/util/util.js
@@ -35,6 +35,10 @@ export function clearInputForm() {
   });
 }
 
+export function resetSelectElements() {
+  [...$all("select")].forEach(selectElement => selectElement.value = "default");
+}
+
 export const $ = document.querySelector.bind(document);
 
 export const $all = document.querySelectorAll.bind(document);


### PR DESCRIPTION
- 수정 상태인지 아닌지에 따라 다른 버튼(내용 지우기 - 삭제) 을 보여줍니다
- 내용지우기 버튼 클릭 시, 입력했던 내용들을 초기화 합니다
- 삭제 버튼 클릭 시, 서버(db) 에 있는 transaction 레코드를 삭제합니다
