### PR TITLE
[버그수정] #74 결제 수단을 삭제 했을때 transaction 테이블의 레코드가 연쇄적으로  삭제되는 버그 수정

### DIFF
--- a/server/model/payment.js
+++ b/server/model/payment.js
@@ -1,3 +1,5 @@
+const { DELETE_BINARY_VALUE } = require("../utils/contant");
+
 class Payment {
   constructor(db) {
     this.db = db;
@@ -6,7 +8,7 @@ class Payment {
   async findByUserId(id) {
     const conn = await this.db.getConnection();
     try {
-      const query = "select id as payment_id, payment_name from payment where user_id=?";
+      const query = "select id as payment_id, payment_name from payment where user_id=? and is_deleted=0";
       const [rows] = await conn.query(query, [id]);
       if(rows.length === 0) return [];
 
@@ -40,15 +42,10 @@ class Payment {
   async deleteById(p_id) {
     const conn = await this.db.getConnection();
     try {
-      await conn.beginTransaction();
+      const deletePaymentQuery = "UPDATE payment SET is_deleted=? WHERE id=?";
 
-      const deletePaymentQuery = `DELETE FROM payment
-              WHERE id=?`;
-
-      await conn.query(deletePaymentQuery, [p_id]);
-      await conn.commit();
+      await conn.query(deletePaymentQuery, [DELETE_BINARY_VALUE, p_id]);
     } catch (error) {
-      conn.rollback();
       throw error;
     } finally {
       conn.release();

--- a/server/utils/contant.js
+++ b/server/utils/contant.js
@@ -3,4 +3,5 @@ module.exports = {
   INCOME_TYPE: "수입",
   OUTCOME_BINARY_VALUE: 0,
   INCOME_BINARY_VALUE: 1,
+  DELETE_BINARY_VALUE: 1,
 };


### PR DESCRIPTION
- payment 테이블에 is_deleted 필드추가
- payment모델의 deleteById 에서 삭제 시 is_delted를 1로 set
- payment 모델의 find에서 is_deleted가 0인 레코드만 가져옴